### PR TITLE
Fix VK_DEFINE_HANDLE macro

### DIFF
--- a/examples/vulkan/generate.odin
+++ b/examples/vulkan/generate.odin
@@ -75,7 +75,7 @@ macro_define_handle :: proc(data : ^bindgen.ParserData) {
     append(&data.nodes.structDefinitions, structNode);
 
     sourceType : bindgen.IdentifierType;
-    sourceType.name = structName;
+    sourceType.name = append("^", structName);
 
     typedefNode : bindgen.TypedefNode;
     typedefNode.name = object;


### PR DESCRIPTION
object is aliased as object_T* -> object :: ^objectT